### PR TITLE
Commit 6: Docker Compose full demo (api + worker + postgres)

### DIFF
--- a/init_docker_shell.sh
+++ b/init_docker_shell.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo usermod -aG docker "$USER"
+newgrp docker
+docker ps


### PR DESCRIPTION
Adds Dockerfile + .dockerignore and extends docker-compose to run Postgres, run Alembic migrations (one-shot), start FastAPI API and worker. Includes docs and dependency fixes.\n\nCloses #26