### PR TITLE
Commit 7: add /audit-log (read-only) with RBAC + pagination

### DIFF
--- a/app/api/routes_audit_log.py
+++ b/app/api/routes_audit_log.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+
+from app.auth import require_role
+from app.db import get_session
+from app.schemas import AuditLogOut
+from app.services.audit_service import list_audit_logs
+
+router = APIRouter(prefix="/audit-log", tags=["audit-log"])
+
+
+@router.get(
+    "",
+    response_model=list[AuditLogOut],
+    dependencies=[Depends(require_role(["auditor", "admin"]))],
+)
+def get_audit_log(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+):
+    with get_session() as session:
+        return list_audit_logs(session, offset=offset, limit=limit)

--- a/app/main.py
+++ b/app/main.py
@@ -6,13 +6,18 @@ from app.api.routes_suppliers import router as suppliers_router
 from app.api.routes_ncs import router as ncs_router
 from app.api.routes_kpi import router as kpi_router
 from app.api.routes_auth import router as auth_router
+from app.api.routes_audit_log import router as audit_log_router
 
-app = FastAPI(title="QHSE Supply Chain Demo (Sinergest-like)")
+
+app = FastAPI(title="QHSE Supply Chain - Demo")
+
 
 app.include_router(suppliers_router)
 app.include_router(kpi_router)
 app.include_router(ncs_router)
 app.include_router(auth_router)
+app.include_router(audit_log_router)
+
 
 @app.get("/health")
 def health():

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional, Literal
 from pydantic import BaseModel, Field, ConfigDict
+from datetime import datetime
 
 
 Severity = Literal["low", "medium", "high"]
@@ -51,3 +52,15 @@ class SupplierDetailOut(BaseModel):
 
 class SupplierCertUpdate(BaseModel):
     certification_expiry: Optional[str] = Field(default=None, description="YYYY-MM-DD (demo)")
+
+
+class AuditLogOut(BaseModel):
+    id: int
+    actor: str
+    action: str
+    entity_type: str
+    entity_id: str
+    meta_json: str
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/app/services/audit_service.py
+++ b/app/services/audit_service.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from sqlalchemy import select
+
+from app.models import AuditLog
+
+
+def list_audit_logs(session, offset: int = 0, limit: int = 20) -> list[AuditLog]:
+    q = (
+        select(AuditLog)
+        .order_by(AuditLog.id.desc())  # latest first
+        .offset(offset)
+        .limit(limit)
+    )
+    return list(session.execute(q).scalars().all())

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from app.db import get_session
+from app.models import AuditLog
+from tests.utils_auth import auth_headers, login_and_get_token
+
+
+def _seed_audit_logs(n: int = 3) -> None:
+    with get_session() as s:
+        for i in range(n):
+            s.add(
+                AuditLog(
+                    actor="system",
+                    action=f"action-{i}",
+                    entity_type="nc",
+                    entity_id=str(100 + i),
+                    meta_json="{}",
+                )
+            )
+
+
+def test_audit_log_requires_auth(client):
+    r = client.get("/audit-log")
+    assert r.status_code == 401, r.text
+
+
+def test_audit_log_forbidden_for_quality(client):
+    _seed_audit_logs(2)
+    token = login_and_get_token(client, "quality", "quality")
+    r = client.get("/audit-log", headers=auth_headers(token))
+    assert r.status_code == 403, r.text
+
+
+def test_audit_log_allowed_for_auditor_with_pagination(client):
+    _seed_audit_logs(3)
+    token = login_and_get_token(client, "auditor", "auditor")
+
+    r1 = client.get("/audit-log?limit=2&offset=0", headers=auth_headers(token))
+    assert r1.status_code == 200, r1.text
+    data1 = r1.json()
+    assert isinstance(data1, list)
+    assert len(data1) == 2
+
+    r2 = client.get("/audit-log?limit=2&offset=2", headers=auth_headers(token))
+    assert r2.status_code == 200, r2.text
+    data2 = r2.json()
+    assert isinstance(data2, list)
+    assert len(data2) == 1


### PR DESCRIPTION
Adds GET /audit-log endpoint with limit/offset pagination, protected for auditor/admin. Includes tests.\n\nCloses #<numero_issue>